### PR TITLE
Remove reference to offat* Linux preload

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,10 +178,9 @@ The `preload/` directory contains useful library functions that you may want to
 include from your scripts. In working with Windows guests, you may find
 `preload/pdb2structs.py` to be helpful --- it turns Windows .pdb files into
 Emmett structure definitions. In working with Linux guests, you may find
-`preload/linux-module/` to be helpful --- it has an expanded and updated
-version of the `preload/linux*-2.6-preload.emt` preloads, using a custom Linux
-kernel module to expose the offsets within structures (see that directory for
-details).
+`preload/linux-module/` to be helpful --- it contains a preload for Linux that
+uses a custom Linux kernel module to expose the offsets within structures (see
+that directory for details).
 
 ## Support
 


### PR DESCRIPTION
In commit 158ddb6bb9c56d73469b907c8e3d8b392ad3b4e5, Vivek removed the Linux
preloads that used offat\* to find offsets. This updates the README to no longer
reference those preloads.
